### PR TITLE
Dot throw exception if sill-prestataires.json is down

### DIFF
--- a/src/core/adapters/compileData.ts
+++ b/src/core/adapters/compileData.ts
@@ -33,6 +33,11 @@ export function createCompileData(params: {
             comptoirDuLibreApi.getComptoirDuLibre(),
             getCnllPrestatairesSill()
         ]);
+
+        if (getCachedSoftware === undefined) {
+            getServiceProviders.clear();
+        }
+
         const serviceProvidersBySillId = await getServiceProviders();
 
         const { partialSoftwareBySillId } = await (async () => {
@@ -308,7 +313,7 @@ export function createCompileData(params: {
                     referents,
                     users
                 }): CompiledData.Software<"private"> => ({
-                    serviceProviders: serviceProvidersBySillId[sillId] ?? [],
+                    "serviceProviders": serviceProvidersBySillId[sillId] ?? [],
                     "id": sillId,
                     name,
                     description,

--- a/src/core/adapters/getServiceProviders.ts
+++ b/src/core/adapters/getServiceProviders.ts
@@ -14,24 +14,30 @@ type SillIdAndPrestataireFromApi = {
     }>;
 };
 
+const url = "https://code.gouv.fr/data/sill-prestataires.json";
+
 export const getServiceProviders: GetServiceProviders = memoize(
     () =>
-        fetch("https://code.gouv.fr/data/sill-prestataires.json")
+        fetch(url)
             .then(response => response.json())
             .then((serviceProvidersFromApi: SillIdAndPrestataireFromApi[]) =>
                 serviceProvidersFromApi.reduce(
                     (acc, { sill_id, prestataires }) => ({
                         ...acc,
                         [sill_id]: prestataires.map(prestataire => ({
-                            name: prestataire.nom,
-                            website: prestataire.website,
-                            cdlUrl: prestataire.cdl_url,
-                            cnllUrl: prestataire.cnll_url,
-                            siren: prestataire.siren
+                            "name": prestataire.nom,
+                            "website": prestataire.website,
+                            "cdlUrl": prestataire.cdl_url,
+                            "cnllUrl": prestataire.cnll_url,
+                            "siren": prestataire.siren
                         }))
                     }),
                     id<ServiceProvidersBySillId>({})
                 )
-            ),
+            )
+            .catch(error => {
+                console.error(`Failed to fetch ${url}: ${String(error)}`);
+                return {};
+            }),
     { "promise": true, "maxAge": 3 * 3600 * 1000 }
 );

--- a/src/core/ports/GetServiceProviders.ts
+++ b/src/core/ports/GetServiceProviders.ts
@@ -2,4 +2,7 @@ import { ServiceProvider } from "../usecases/readWriteSillData";
 
 export type ServiceProvidersBySillId = Partial<Record<string, ServiceProvider[]>>;
 
-export type GetServiceProviders = () => Promise<ServiceProvidersBySillId>;
+export type GetServiceProviders = {
+    (): Promise<ServiceProvidersBySillId>;
+    clear: () => void;
+};


### PR DESCRIPTION
Hello @JeromeBu,  

I had to do this because I was getting some error trying to edit software on the SILL.  

What I did:  

- Do not throw a runtime exception if `https://code.gouv.fr/data/sill-prestataires.json` is down or has been updated in a way that make it unparsable.  
- Please use double quote for property names for consitency with the rest of the codebase.  
- I made the port clearable so we can ensure we get the latest version of the prestataires when compiling from scratch (non incrementally).  

Thanks for your attention.  